### PR TITLE
fix: Refresh session every 25 minutes to prevent logout

### DIFF
--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -1,42 +1,58 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
-import "./App.css";
-import Dashboard from "./components/Dashboard";
-import { Layout } from "./components/Layout/Layout";
-import Login from "./components/Login";
-import MyFiles from "./components/MyFiles";
-import { Authenticated, Roles } from "./authentication";
-import {Registration} from "./components/Registration/Registration.tsx";
+import { BrowserRouter, Route, Routes } from "react-router-dom"
+import "./App.css"
+import { Authenticated, Roles, useRefreshSession } from "./authentication"
+import Dashboard from "./components/Dashboard"
+import { Layout } from "./components/Layout/Layout"
+import Login from "./components/Login"
+import MyFiles from "./components/MyFiles"
+import { Registration } from "./components/Registration/Registration.tsx"
 
-const approvedRoles = [Roles.ORGANISATION, Roles.TREY_BOARD, Roles.ADMIN];
+const approvedRoles = [Roles.ORGANISATION, Roles.TREY_BOARD, Roles.ADMIN]
 
-const App = ()=> {
-    return <BrowserRouter>
-            <Routes>
+const App = () => {
+  useRefreshSession()
 
-                <Route path="/dashboard" element={<Authenticated requiredRoles={approvedRoles} redirectUrl={"/registration"}>
-                        <Layout>
-                            <Dashboard/>
-                        </Layout>
-                    </Authenticated>}/>
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route
+          path="/dashboard"
+          element={
+            <Authenticated requiredRoles={approvedRoles} redirectUrl={"/registration"}>
+              <Layout>
+                <Dashboard />
+              </Layout>
+            </Authenticated>
+          }
+        />
 
-                <Route path="/my-files" element={<Authenticated requiredRoles={approvedRoles} redirectUrl={"/registration"}>
-                        <Layout>
-                            <MyFiles/>
-                        </Layout>
-                    </Authenticated>}/>
+        <Route
+          path="/my-files"
+          element={
+            <Authenticated requiredRoles={approvedRoles} redirectUrl={"/registration"}>
+              <Layout>
+                <MyFiles />
+              </Layout>
+            </Authenticated>
+          }
+        />
 
-                <Route path="/login" element={<Login/>}/>
-                <Route path="/" element={<Login/>}/>
+        <Route path="/login" element={<Login />} />
+        <Route path="/" element={<Login />} />
 
-                <Route path="registration" element={
-                    <Authenticated requiredRoles={[Roles.NONE]} redirectUrl={"/registration"} >
-                        <Layout>
-                            <Registration />
-                        </Layout>
-                    </Authenticated>}>
-                </Route>
-            </Routes>
+        <Route
+          path="registration"
+          element={
+            <Authenticated requiredRoles={[Roles.NONE]} redirectUrl={"/registration"}>
+              <Layout>
+                <Registration />
+              </Layout>
+            </Authenticated>
+          }
+        ></Route>
+      </Routes>
     </BrowserRouter>
+  )
 }
 
 export default App

--- a/src/web/src/authentication/authRefresh.ts
+++ b/src/web/src/authentication/authRefresh.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react"
+import { useStytch } from "@stytch/react"
+
+export const useRefreshSession = () => {
+  const stytch = useStytch()
+  useEffect(() => {
+    const authenticate = () => {
+      if (stytch.session.getSync()) {
+        stytch.session.authenticate({
+          session_duration_minutes: 30,
+        })
+      }
+    }
+    // Refresh session every 25 minutes
+    const interval = setInterval(authenticate, 25 * 60000)
+    return () => clearInterval(interval)
+  }, [stytch])
+}

--- a/src/web/src/authentication/index.ts
+++ b/src/web/src/authentication/index.ts
@@ -1,2 +1,3 @@
-export { Authenticated } from './Authenticated';
-export { Roles } from './Roles';
+export { Authenticated } from "./Authenticated"
+export { Roles } from "./Roles"
+export { useRefreshSession } from "./authRefresh"


### PR DESCRIPTION
Stytch session length is set to 30 minutes and it's not refreshed at any point. I added an `useEffect` to refresh the session every 25 minutes to prevent user being logged out when the session gets stale.