### PR TITLE
fix: use RBAC to access keyvault

### DIFF
--- a/infra/core/security/keyvault.bicep
+++ b/infra/core/security/keyvault.bicep
@@ -9,6 +9,8 @@ param principalId string = ''
 param enabledForDeployment bool = false
 @description('Allow the key vault to be used for template deployment.')
 param enabledForTemplateDeployment bool = false
+@description('Enable RBAC authorization for KeyVault')
+param enableRbacAuthorization bool = true
 
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   name: name
@@ -26,6 +28,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     ] : []
     enabledForDeployment: enabledForDeployment
     enabledForTemplateDeployment: enabledForTemplateDeployment
+    enableRbacAuthorization: enableRbacAuthorization
   }
 }
 

--- a/infra/core/security/resource-role.bicep
+++ b/infra/core/security/resource-role.bicep
@@ -1,0 +1,29 @@
+metadata description = 'Creates a role assignment for a service principal on a specific resource.'
+param principalId string
+
+@allowed([
+  'Device'
+  'ForeignGroup'
+  'Group'
+  'ServicePrincipal'
+  'User'
+])
+param principalType string = 'ServicePrincipal'
+param roleDefinitionId string
+param resourceId string
+
+var fullRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)
+
+resource existingResource 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+  name: last(split(resourceId, '/'))
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, resourceGroup().id, principalId, roleDefinitionId, resourceId)
+  scope: existingResource
+  properties: {
+    principalId: principalId
+    principalType: principalType
+    roleDefinitionId: fullRoleDefinitionId
+  }
+} 

--- a/infra/core/security/role.bicep
+++ b/infra/core/security/role.bicep
@@ -11,11 +11,13 @@ param principalId string
 param principalType string = 'ServicePrincipal'
 param roleDefinitionId string
 
+var fullRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)
+
 resource role 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(subscription().id, resourceGroup().id, principalId, roleDefinitionId)
   properties: {
     principalId: principalId
     principalType: principalType
-    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)
+    roleDefinitionId: fullRoleDefinitionId
   }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -86,13 +86,16 @@ module api './app/api.bicep' = {
   }
 }
 
-// Give the API access to KeyVault
-module apiKeyVaultAccess './core/security/keyvault-access.bicep' = {
-  name: 'api-keyvault-access'
+// Give the API the Key Vault Secrets User role to access Key Vault
+module apiKeyVaultRoleAssignment 'core/security/resource-role.bicep' = {
+  name: 'api-keyvault-role'
   scope: rg
   params: {
-    keyVaultName: keyVault.outputs.name
     principalId: api.outputs.SERVICE_API_IDENTITY_PRINCIPAL_ID
+    // Key Vault Secrets User role
+    roleDefinitionId: '4633458b-17de-408a-b874-0445c86b69e6'
+    principalType: 'ServicePrincipal'
+    resourceId: keyVault.outputs.id
   }
 }
 

--- a/src/api/Program.cs
+++ b/src/api/Program.cs
@@ -6,7 +6,17 @@ using Trey.Api.Middleware;
 using Trey.Api.Repositories;
 using Trey.Api.Services;
 
-var credential = new DefaultAzureCredential();
+var credentialOptions = new DefaultAzureCredentialOptions
+{
+    ExcludeSharedTokenCacheCredential = true,
+    ExcludeVisualStudioCredential = true,
+    ExcludeVisualStudioCodeCredential = true,
+    ExcludeAzureCliCredential = false,
+    ExcludeInteractiveBrowserCredential = true,
+    ManagedIdentityClientId = null, // Will automatically use the system-assigned managed identity
+    Diagnostics = { IsLoggingEnabled = true, IsAccountIdentifierLoggingEnabled = true, IsDistributedTracingEnabled = true },
+};
+var credential = new DefaultAzureCredential(credentialOptions);
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton(_ => new CosmosClient(builder.Configuration["AZURE_COSMOS_ENDPOINT"], credential,


### PR DESCRIPTION
I noted this access was still missing after deploy. This makes access more explicit.