### PR TITLE
fix: add storage reader role to function app

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -136,6 +136,16 @@ module storageContribRoleFunction 'core/security/role.bicep' = {
   }
 }
 
+module storageReaderRoleFunction 'core/security/role.bicep' = {
+  scope: rg
+  name: 'storage-readerrole-api'
+  params: {
+    principalId: api.outputs.SERVICE_API_IDENTITY_PRINCIPAL_ID
+    roleDefinitionId: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+    principalType: 'ServicePrincipal'
+  }
+}
+
 // The application database
 module cosmos './app/db.bicep' = {
   name: 'cosmos'


### PR DESCRIPTION
Adds the storage reader role to the function app. This should fix the error we get when reading files from the backend