### PR TITLE
fix: Use TryGetValue to fetch organizationId and role

### DIFF
--- a/src/api/Services/AuthService.cs
+++ b/src/api/Services/AuthService.cs
@@ -34,8 +34,8 @@ internal sealed class AuthService(ConsumerClient client) : IAuthService
         return new TreyUser
         {
             Name = user.Name.FirstName + " " + user.Name.LastName,
-            OrganizationId = metadata["organizationId"] ?? "",
-            Role = metadata["role"].ToTreyRole()
+            OrganizationId = metadata.TryGetValue("organizationId", out string? value) ? value : "",
+            Role = metadata.TryGetValue("role", out string? role) ? role.ToTreyRole() : TreyRole.None,
         };
     }
 


### PR DESCRIPTION
Previously when trying to read organizationId and role and either of those were undefined, the backend threw an error. Using `TryGetValue` fixes that.